### PR TITLE
MLPAB-2794 - add support for domain list rule groups

### DIFF
--- a/refactor.tf
+++ b/refactor.tf
@@ -1,0 +1,4 @@
+moved {
+  from = aws_networkfirewall_rule_group.main
+  to   = aws_networkfirewall_rule_group.rule_file
+}

--- a/variables.tf
+++ b/variables.tf
@@ -96,3 +96,9 @@ variable "network_firewall_rules_file" {
   type        = string
   description = "path to the file containing the network firewall rules in suricata format"
 }
+
+variable "domain_allow_list" {
+  type        = list(string)
+  description = "List of domains that you want to allow egress to"
+  default     = []
+}


### PR DESCRIPTION
# Purpose

Support egress management using domain lists, while support the ability to use Suricata rule format files.

Fixes MLPAB-2794

## Approach

My intention is to support having both inputs, creating 2 rule groups and having them both be attached to the firewall with a single policy

- add domain list rule group
- rename rule group main to rule_file
- attach both rule groups to policy
- TODO: conditionally create rule group if input exists
- TODO: conditionally attach rule group if rule group exists

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_rule_group#rules-source-list
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall_policy


